### PR TITLE
fixed finnhub news display in carousel

### DIFF
--- a/moneyApp/src/components/Carousel.jsx
+++ b/moneyApp/src/components/Carousel.jsx
@@ -28,7 +28,7 @@ export default function Carousel() {
         }
     ]
     useEffect(() => {
-        fetch("http://localhost:5000/api/news")
+        fetch("http://localhost:5001/api/news")
             .then(res => res.json())
             .then(data => setNews(data))
             .catch(err => console.error("News fetch error:", err));


### PR DESCRIPTION
uses finnhub api to display financial news in the carousel in the home page

requires FINNHUB_API_KEY to .env file inside database folder